### PR TITLE
Ajuste no TaskItem: exibir apenas o título da tarefa

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,48 +9,46 @@ import { TaskCard } from "./components/component.TaskCard/TaskCard";
 
 export default function App() {
   const [tasks, setTasks] = useState<Task[]>([
-    // Fundamentos Web completo
+    // Módulos pré-preenchidos
     { id: crypto.randomUUID(), title: "Revisar estrutura HTML", category: "Fundamentos Web", completed: true },
     { id: crypto.randomUUID(), title: "Criar uma página simples", category: "Fundamentos Web", completed: true },
-    
-    // Backend Development completo
     { id: crypto.randomUUID(), title: "Instalar Node.js", category: "Backend Development", completed: true },
     { id: crypto.randomUUID(), title: "Criar API REST básica", category: "Backend Development", completed: true },
   ]);
 
   const [selected, setSelected] = useState<string | null>(null);
 
-  // Adiciona nova tarefa
   function handleAddTask(title: string, category: string) {
     const newTask: Task = { id: crypto.randomUUID(), title, category, completed: false };
     setTasks((prev) => [...prev, newTask]);
   }
 
-  // Alterna status de conclusão
   function handleToggle(id: string) {
     setTasks((prev) =>
       prev.map((task) => (task.id === id ? { ...task, completed: !task.completed } : task))
     );
   }
 
-  // Deleta tarefa
   function handleDelete(id: string) {
     setTasks((prev) => prev.filter((task) => task.id !== id));
   }
 
-  // Filtros por categoria
   const fundamentosWebTasks = tasks.filter(task => task.category === "Fundamentos Web");
   const backendDevelopmentTasks = tasks.filter(task => task.category === "Backend Development");
   const frontendFrameworkTasks = tasks.filter(task => task.category === "Frontend Framework");
   const backendAvancadoTasks = tasks.filter(task => task.category === "Backend Avançado");
 
-  // Progresso dos módulos
   const completedModulesCount = [
     fundamentosWebTasks.length > 0 && fundamentosWebTasks.every(task => task.completed),
     backendDevelopmentTasks.length > 0 && backendDevelopmentTasks.every(task => task.completed),
     frontendFrameworkTasks.length > 0 && frontendFrameworkTasks.every(task => task.completed),
     backendAvancadoTasks.length > 0 && backendAvancadoTasks.every(task => task.completed),
   ].filter(Boolean).length;
+
+  // Função para decidir se o título do módulo deve aparecer
+  const showTitle = (tasksInModule: Task[]) => {
+    return tasksInModule.every(task => task.completed);
+  };
 
   return (
     <>
@@ -68,6 +66,7 @@ export default function App() {
             onSelect={() =>
               setSelected(selected === "Fundamentos Web" ? null : "Fundamentos Web")
             }
+            showTitle={showTitle(fundamentosWebTasks)}
           />
         )}
 
@@ -81,6 +80,7 @@ export default function App() {
             onSelect={() =>
               setSelected(selected === "Backend Development" ? null : "Backend Development")
             }
+            showTitle={showTitle(backendDevelopmentTasks)}
           />
         )}
 
@@ -94,6 +94,7 @@ export default function App() {
             onSelect={() =>
               setSelected(selected === "Frontend Framework" ? null : "Frontend Framework")
             }
+            showTitle={showTitle(frontendFrameworkTasks)}
           />
         )}
 
@@ -107,6 +108,7 @@ export default function App() {
             onSelect={() =>
               setSelected(selected === "Backend Avançado" ? null : "Backend Avançado")
             }
+            showTitle={showTitle(backendAvancadoTasks)}
           />
         )}
       </div>

--- a/src/components/component.TaskCard/TaskCard.tsx
+++ b/src/components/component.TaskCard/TaskCard.tsx
@@ -9,9 +9,10 @@ interface TaskCardProps {
   onDelete: (id: string) => void;
   selected: boolean;
   onSelect: () => void;
+  showTitle?: boolean; // adiciona a prop opcional
 }
 
-export function TaskCard({ title, tasks, onToggle, onDelete, selected, onSelect }: TaskCardProps) {
+export function TaskCard({ title, tasks, onToggle, onDelete, selected, onSelect, showTitle = true }: TaskCardProps) {
   const completedCount = tasks.filter(task => task.completed).length;
   const progress = tasks.length > 0 ? (completedCount / tasks.length) * 100 : 0;
 
@@ -20,7 +21,8 @@ export function TaskCard({ title, tasks, onToggle, onDelete, selected, onSelect 
       className={`${styles.card} ${selected ? styles.selected : ""}`}
       onClick={onSelect}
     >
-      <h3 className={styles.title}>{title}</h3>
+      {/* Renderiza o título apenas se showTitle for true */}
+      {showTitle && <h3 className={styles.title}>{title}</h3>}
 
       {/* Barra de progresso */}
       <div className={styles.progressBar}>

--- a/src/components/component.TaskItem/TaskItem.tsx
+++ b/src/components/component.TaskItem/TaskItem.tsx
@@ -9,20 +9,17 @@ type props = {
 
 export default function TaskItem({ task, onToggle, onDelete }: props) {
   return (
-    <>
-      <div className={styles.container}>
-        <input
-          type="checkbox"
-          checked={task.completed}
-          onChange={() => onToggle(task.id)}
-        />
-        <span>{task.title}</span>
-        <span>({task.category})</span>
+    <div className={styles.container}>
+      <input
+        type="checkbox"
+        checked={task.completed}
+        onChange={() => onToggle(task.id)}
+      />
+      <span>{task.title}</span>
 
-        <button className={styles.buttonExcluir} onClick={() => onDelete(task.id)}>
-          🗑️
-        </button>
-      </div>
-    </>
+      <button className={styles.buttonExcluir} onClick={() => onDelete(task.id)}>
+        🗑️
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
O que foi feito:
- Removida a exibição da categoria ao lado do título nas tarefas.
- Agora cada TaskItem mostra apenas o título da tarefa e o botão de exclusão.
- Mantido o comportamento de marcar como concluída normalmente.

Motivo:
- Simplificação da interface e foco apenas no conteúdo das tarefas.
